### PR TITLE
Making the test automations' names more unique

### DIFF
--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -191,22 +191,31 @@ async def assess_compound_automation():
             )
         )
 
+        previous = None
         async with PrefectCloudEventsClient() as events:
             for i in range(5):
+                current = uuid4()
                 await events.emit(
                     Event(
+                        id=current,
+                        follows=previous,
                         event="integration.example.event.A",
                         resource=expected_resource,
                         payload={"iteration": i},
                     )
                 )
+                previous = current
+                current = uuid4()
                 await events.emit(
                     Event(
+                        id=current,
+                        follows=previous,
                         event="integration.example.event.B",
                         resource=expected_resource,
                         payload={"iteration": i},
                     )
                 )
+                previous = current
 
         # Wait until we see the automation triggered event, or fail if it takes longer
         # than 60 seconds.  The compound trigger should fire almost immediately.


### PR DESCRIPTION
This change appends a uuid the name of each automation we create during the
integration tests, and also cleans up any stragglers older than 10 minutes (in
case of errors cleaning up older runs).  This should help to prevent any
two runs (or a dev working locally) from interfering with the deployed tests.

While I've been in here, I've also been tuning/simplifying these tests to be
more reliable, so there are some additional changes snuck in.