### PR TITLE
Loosens the two proactive alert automations

### DIFF
--- a/flows/ensure-integration-automations.py
+++ b/flows/ensure-integration-automations.py
@@ -119,7 +119,7 @@ async def ensure_integrations_automations():
                 ],
                 "for_each": ["prefect.resource.id"],
                 "threshold": 1,
-                "within": 90,
+                "within": 300,
             },
             "actions": [
                 {
@@ -158,7 +158,7 @@ async def ensure_integrations_automations():
                 ],
                 "for_each": ["prefect.resource.id"],
                 "threshold": 1,
-                "within": 600,
+                "within": 900,
             },
             "actions": [
                 {
@@ -188,7 +188,7 @@ async def ensure_integrations_automations():
             ),
             "trigger": {
                 "posture": "Proactive",
-                "after": ["prefect.work-pool.not_ready"],
+                "after": ["prefect.work-pool.not-ready"],
                 "expect": ["prefect.work-pool.ready"],
                 "for_each": ["prefect.resource.id"],
                 "threshold": 1,


### PR DESCRIPTION
We've been seeing flapping of the integation test proactive automations, so
let's give them more breathing room so they only fire if there's really a
problem to look at.

This also adjusts to the new spelling of the work-pool not-ready event.

Part of PrefectHQ/nebula#7676
