### PR TITLE
Fixing a race condition with automation assessments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pre-commit
-prefect>=2.16.3
+prefect>=2.19.4
 ruff


### PR DESCRIPTION
One way that these automation tests could fail is if connecting to the websocket
to listen for the triggered event takes longer than it takes to emit the
events and trigger the automation.  Looking back through Slack for the times 
when these have failed with their `TimeoutError`, it's always been the reactive
and composite triggers, which lends support to this happening (because they
should fire almost instantly).

By using an `asyncio.Event` to signal when the socket is connected, we can wait 
for that signal before we proceed with the rest of the test.

Part of PrefectHQ/nebula#7676
