### PR TITLE
Adds a new integration test that isolates problems with event streaming

### DIFF
--- a/.github/workflows/prefect-deploy-integration-tests-dev.yaml
+++ b/.github/workflows/prefect-deploy-integration-tests-dev.yaml
@@ -48,6 +48,7 @@ jobs:
           --name "Automations - Proactive"
           --name "Automations - Reactive"
           --name "Automations - Sequence"
+          --name "Events - Streaming"
           --name "Flow Pauses"
           --name "Flow Results"
           --name "Flow Retries With Subflows"

--- a/.github/workflows/prefect-deploy-integration-tests-stg.yaml
+++ b/.github/workflows/prefect-deploy-integration-tests-stg.yaml
@@ -48,6 +48,7 @@ jobs:
           --name "Automations - Proactive"
           --name "Automations - Reactive"
           --name "Automations - Sequence"
+          --name "Events - Streaming"
           --name "Flow Pauses"
           --name "Flow Results"
           --name "Flow Retries With Subflows"

--- a/flows/event-streaming.py
+++ b/flows/event-streaming.py
@@ -1,0 +1,104 @@
+import asyncio
+from uuid import uuid4
+
+import pendulum
+from prefect import flow, get_client, get_run_logger
+from prefect.events import Event, Resource
+from prefect.events.clients import get_events_client, get_events_subscriber
+from prefect.events.filters import (
+    EventFilter,
+    EventNameFilter,
+    EventOccurredFilter,
+    EventResourceFilter,
+)
+
+
+async def wait_for_event(listening: asyncio.Event, filter: EventFilter) -> Event:
+    logger = get_run_logger()
+
+    logger.info("Starting event subscriber...")
+
+    async with get_events_subscriber(filter=filter) as subscriber:
+        logger.info("Subscribed and waiting for events...")
+        listening.set()
+        async for event in subscriber:
+            logger.info(event)
+            return event
+
+    raise Exception("Disconnected without an event")
+
+
+@flow
+async def event_streaming():
+    logger = get_run_logger()
+
+    expected_resource = Resource(
+        {"prefect.resource.id": f"integration:streaming:{uuid4()}"}
+    )
+
+    filter = EventFilter(
+        occurred=EventOccurredFilter(since=pendulum.now("UTC")),
+        event=EventNameFilter(name=["integration.example.event"]),
+        resource=EventResourceFilter(id=[expected_resource.id]),
+    )
+
+    listening = asyncio.Event()
+    listener = asyncio.create_task(wait_for_event(listening, filter))
+    await listening.wait()
+
+    logger.info("Emitting example events for %r...", expected_resource)
+    async with get_events_client() as events:
+        await events.emit(
+            Event(
+                event="integration.example.event",
+                resource=expected_resource,
+            )
+        )
+
+    allowance = 60
+
+    try:
+        async with asyncio.timeout(allowance):
+            await listener
+    except asyncio.TimeoutError:
+        message = (
+            f"Event was not received within {allowance}s, but it should be nearly "
+            "instantaneous. "
+        )
+        async with get_client() as client:
+            response = await client._client.post(
+                "/events/filter",
+                json={
+                    "filter": filter.model_dump(mode="json"),
+                },
+            )
+            if response.status_code != 200:
+                message += (
+                    "When trying to retrieve events via the API, we got "
+                    f"a non-200 status code {response.status_code}. "
+                )
+            else:
+                page = response.json()
+                if page["total"] == 0:
+                    message += (
+                        "It wasn't visible on the /events/filter endpoint either, "
+                        "which means there could be a problem with the inbound event "
+                        "websocket /events/in. "
+                    )
+                else:
+                    message += (
+                        "It was visible on the /events/filter endpoint, which means "
+                        "there could be a problem with the outbound event websocket "
+                        "/events/out. "
+                    )
+
+            message += (
+                "This is likely to cause flakes with the automations integration "
+                "tests, so diagnose this problem first."
+            )
+
+            raise Exception(message)
+
+
+if __name__ == "__main__":
+    asyncio.run(event_streaming())

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -93,6 +93,14 @@ deployments:
     entrypoint: flows/automation-assessments.py:assess_sequence_automation
     work_pool: *kubernetes_prd_internal_tools
 
+  - name: Events - Streaming
+    tags:
+      - expected:success
+    description: *integration_tests
+    schedule: *every_five_minutes
+    entrypoint: flows/event-streaming.py:event_streaming
+    work_pool: *kubernetes_prd_internal_tools
+
   - name: Flow Pauses
     tags:
       - expected:failure


### PR DESCRIPTION
If we have problems with event inbound or outbound streaming, our automations
tests will also fail.  This makes it unclear whether the problem is with the
automations or with event streaming in general.  This test will fail when there
is _just_ a problem with events.
