### PR TITLE
feat: add local testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,41 @@ Then run:
 prefect profiles use server
 prefect --no-prompt deploy --name "Flow Pauses" --name "Flow Results" --name "Flow Retries With Subflows" --name "Flow Retries" --name "Hello Tasks" --name "Secret Block" --name "Task Burst" --name "Task Results" --name "Task Retries"
 ```
+
+## Local testing with Docker Compose
+
+There is also a Docker Compose setup you can use to bootstrap a local instance
+of Prefect OSS.
+
+First, start Prefect OSS:
+
+```bash
+docker compose up -d
+```
+
+Next, set your Prefect profile to target the local instance of Prefect OSS:
+
+```bash
+prefect profile create local
+prefect profile use local
+prefect profile set PREFECT_API_URL="http://localhost:4200/api"
+```
+
+Now, start the workers:
+
+```bash
+# Install dependencies
+pip install prefect prefect-docker
+
+# Start the workers matching the names in prefect.yaml
+prefect worker start --pool "kubernetes-prd-internal-tools"
+prefect worker start --pool "managed-work-pool"
+```
+
+Finally, create the deployments:
+
+```bash
+prefect deploy --no-prompt --all
+```
+
+You should see the deployments at [http://localhost:4200/deployments](http://localhost:4200/deployments).

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+# This file is used to run a local instance of
+# Prefect for testing our Terraform Provider.
+#
+# See ./_about/CONTRIBUTING.md.
+services:
+  prefect:
+    image: prefecthq/prefect:3-latest
+    ports:
+      - "4200:4200"
+    environment:
+      PREFECT_LOGGING_LEVEL: debug
+    command:
+      - prefect
+      - server
+      - start
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "4200"


### PR DESCRIPTION
## Summary

Uses docker compose to facilitate testing the flows locally.

This can also be helpful in the future to reuse some of these flows to bootstrap a new instance of Prefect OSS with data.

This was an idea floating around in my head for a while so I wanted to finally try it out. If this isn't helpful, or if it could be helpful with some tweaks, let me know 👍🏼 

Related to https://linear.app/prefect/issue/PLA-1428/cycle-18-catch-all