### PR TITLE
Add weekly cron trigger to deployment workflows

### DIFF
--- a/.github/workflows/prefect-deploy-integration-tests-dev.yaml
+++ b/.github/workflows/prefect-deploy-integration-tests-dev.yaml
@@ -6,6 +6,8 @@ name: Deploy Prefect integration-tests Workspace Flows - Dev
     branches:
       - main
   workflow_dispatch: {}
+  schedule:
+    - cron: '11 16 * * 3'  # Every Wednesday at 11:11am ET (16:11 UTC)
 
 permissions: {}
 

--- a/.github/workflows/prefect-deploy-integration-tests-prd.yaml
+++ b/.github/workflows/prefect-deploy-integration-tests-prd.yaml
@@ -6,6 +6,8 @@ name: Deploy Prefect integration-tests Workspace Flows - Prd
     branches:
       - main
   workflow_dispatch: {}
+  schedule:
+    - cron: '11 16 * * 3'  # Every Wednesday at 11:11am ET (16:11 UTC)
 
 permissions: {}
 

--- a/.github/workflows/prefect-deploy-integration-tests-stg.yaml
+++ b/.github/workflows/prefect-deploy-integration-tests-stg.yaml
@@ -6,6 +6,8 @@ name: Deploy Prefect integration-tests Workspace Flows - Stg
     branches:
       - main
   workflow_dispatch: {}
+  schedule:
+    - cron: '11 16 * * 3'  # Every Wednesday at 11:11am ET (16:11 UTC)
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Adds cron schedule to all three Prefect deployment workflows (dev, stg, prd)
- Workflows now run automatically every Wednesday at 11:11am ET
- Ensures integration test deployments stay fresh and in sync

🤖 Generated with [Claude Code](https://claude.ai/code)